### PR TITLE
when a player rests, grab refreshed character from backend, save it t…

### DIFF
--- a/src/modals/notifications/rest.js
+++ b/src/modals/notifications/rest.js
@@ -24,7 +24,7 @@ class Rest extends React.Component {
       // check to see if it's true or false by checking spells per day against prepared spells and cast spell levels
       // does not apply for spontaneous casters
 
-      debugger
+      this.props.dispatch({type: 'CHARACTER', character: data.character })
       // should return either updated character // RETURNS NEW CHARACTER
 
       // dispatch new character, clear cast cast spells
@@ -32,6 +32,8 @@ class Rest extends React.Component {
       // or adjusted hps (lethal, non lethal, temp) due to resting
 
       // then do a delete with all cast spells
+      this.props.exitModal()
+
     })
   }
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -22,7 +22,13 @@ const reducer = (state = initialState, action) => {
     case "SIGNOUT":
       return {...state, currentUser: "", admin: false};
     case "CHARACTER":
-      return {...state, character: action.character};
+      let classesCopy = state.character_info.classes
+      let clearedCopy = classesCopy.map(cc => {
+        let copiedClassInfo = {...cc}
+        copiedClassInfo.castSpells = {}
+        return copiedClassInfo
+      })
+      return {...state, character: action.character, character_info: {...state.character_info, classes: clearedCopy}};
     case "ABILITY SCORE":
       return {...state, character_info: {...state.character_info, ability_scores: {...state.character_info.ability_scores, [action.ability]: action.score}}};
     case "CHARACTER_CLASSES":


### PR DESCRIPTION
…o redux. Whenever CHARACTER gets run in redux, which is run on rest, clear all cast spells from each class. On startup, this doesn't affect anything.